### PR TITLE
ci: reduce requests to GPG server to avoid codecov upload failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 4
       matrix:
         go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x]
 
@@ -45,7 +46,7 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: coverage.txt
           flags: go-${{ matrix.go-version }},unittests
           name: go-${{ matrix.go-version }}


### PR DESCRIPTION
1. Set `fail_ci_if_error` to false: IMO the codecov upload failure should not fail the whole tests
2. The upload error may be caused by the current limiting strategy of the default PGP server, I am not sure. set up a smaller (maybe) `max-paralle` to mitigate the problem