### PR TITLE
refactor: UnmarshalBy with zero-copy for string

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,11 +415,11 @@ gmap.ToOrderedSlice(map[int]int{1: 2, 2: 3, 3: 4}, f)
 Example2：High-order Function
 
 ```go
-Map(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) (string, string) {
+gmap.Map(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) (string, string) {
     return strconv.Itoa(k), strconv.Itoa(k + 1)
 })
 // {"1":"2", "2":"3", "3":"4"}
-Filter(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) bool {
+gmap.Filter(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) bool {
     return k+v > 3
 })
 // {"2":2, "3":3}
@@ -579,6 +579,26 @@ gson.Valid(`{"name":"test","age":10}`)
 // true
 gson.Unmarshal[testStruct](`{"name":"test","age":10}`)
 // {test 10} nil
+
+// Use high-performance JSON codecs such as Sonic or json-iterator, instead of the standard library's encoding/json.
+import "github.com/bytedance/sonic"
+
+gson.MarshalBy(sonic.ConfigDefault, testcase)
+// []byte(`{"name":"test","age":10}`) nil
+gson.MarshalString(sonic.ConfigDefault, testcase)
+// {"name":"test","age":10}`, nil
+gson.UnmarshalBy[testStruct](sonic.ConfigDefault, `{"name":"test","age":10}`)
+// testStruct{Name: "test", Age: 10}, nil
+
+// Example using Json-Iterator:
+import jsoniter "github.com/json-iterator/go"
+
+gson.MarshalBy(jsoniter.ConfigDefault, testcase)
+// []byte(`{"name":"test","age":10}`) nil
+gson.MarshalString(jsoniter.ConfigDefault, testcase)   
+// {"name":"test","age":10}`, nil
+gson.UnmarshalBy[testStruct](jsoniter.ConfigDefault, `{"name":"test","age":10}`)
+// testStruct{Name: "test", Age: 10}, nil
 ```
 
 ## ✨ Generic Standard Wrapper

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -415,11 +415,11 @@ gmap.ToOrderedSlice(map[int]int{1: 2, 2: 3, 3: 4}, f)
 示例2：高阶函数
 
 ```go
-Map(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) (string, string) {
+gmap.Map(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) (string, string) {
     return strconv.Itoa(k), strconv.Itoa(k + 1)
 })
 // {"1":"2", "2":"3", "3":"4"}
-Filter(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) bool {
+gmap.Filter(map[int]int{1: 2, 2: 3, 3: 4}, func(k int, v int) bool {
     return k+v > 3
 })
 // {"2":2, "3":3}
@@ -580,6 +580,26 @@ gson.Valid(`{"name":"test","age":10}`)
 // true
 gson.Unmarshal[testStruct](`{"name":"test","age":10}`)
 // {test 10} nil
+
+// 使用高性能 JSON codecs 如Sonic, json-iterator
+import "github.com/bytedance/sonic"
+
+gson.MarshalBy(sonic.ConfigDefault, testcase)
+// []byte(`{"name":"test","age":10}`) nil
+gson.MarshalString(sonic.ConfigDefault, testcase)
+// {"name":"test","age":10}`, nil
+gson.UnmarshalBy[testStruct](sonic.ConfigDefault, `{"name":"test","age":10}`)
+// testStruct{Name: "test", Age: 10}, nil
+
+// Json-Iterator:
+import jsoniter "github.com/json-iterator/go"
+
+gson.MarshalBy(jsoniter.ConfigDefault, testcase)
+// []byte(`{"name":"test","age":10}`) nil
+gson.MarshalString(jsoniter.ConfigDefault, testcase)   
+// {"name":"test","age":10}`, nil
+gson.UnmarshalBy[testStruct](jsoniter.ConfigDefault, `{"name":"test","age":10}`)
+// testStruct{Name: "test", Age: 10}, nil
 ```
 
 ## ✨ 泛型标准库封装

--- a/gson/gson_codec.go
+++ b/gson/gson_codec.go
@@ -136,6 +136,7 @@ func ToStringIndentBy[T any](codec PrettyMarshaler, v T, prefix, indent string) 
 //
 // 💡 HINT: For high-performance JSON decoding, see [github.com/json-iterator/go] or [github.com/bytedance/sonic].
 func UnmarshalBy[T any, V ~[]byte | ~string](codec Unmarshaler, v V) (T, error) {
+	var t T
 	switch tv := any(v).(type) {
 	case string:
 		err := codec.Unmarshal(conv.StringToBytes(tv), &t)

--- a/gson/gson_codec.go
+++ b/gson/gson_codec.go
@@ -144,5 +144,8 @@ func UnmarshalBy[T any, V ~[]byte | ~string](codec Unmarshaler, v V) (T, error) 
 	case []byte:
 		err := codec.Unmarshal(tv, &t)
 		return t, err
+	default:
+		err := codec.Unmarshal([]byte(v), &t) // fallback for robustness: theoretically unreachable due to type constraint V ~[]byte | ~string
+		return t, err
 	}
 }

--- a/gson/gson_codec.go
+++ b/gson/gson_codec.go
@@ -136,7 +136,12 @@ func ToStringIndentBy[T any](codec PrettyMarshaler, v T, prefix, indent string) 
 //
 // 💡 HINT: For high-performance JSON decoding, see [github.com/json-iterator/go] or [github.com/bytedance/sonic].
 func UnmarshalBy[T any, V ~[]byte | ~string](codec Unmarshaler, v V) (T, error) {
-	var t T
-	err := codec.Unmarshal([]byte(v), &t)
-	return t, err
+	switch tv := any(v).(type) {
+	case string:
+		err := codec.Unmarshal(conv.StringToBytes(tv), &t)
+		return t, err
+	case []byte:
+		err := codec.Unmarshal(tv, &t)
+		return t, err
+	}
 }

--- a/gson/gson_codec_test.go
+++ b/gson/gson_codec_test.go
@@ -160,12 +160,6 @@ func TestUnmarshalBy(t *testing.T) {
 			expected := set.New[int32](1, 2, 3)
 			assert.Nil(t, err)
 			assert.Equal(t, expected, got)
-		},
-		{
-			got, err := UnmarshalBy[*set.Set[int32]](codec, `[1,2, 3]`)
-			expected := set.New[int32](1, 2, 3)
-			assert.Nil(t, err)
-			assert.Equal(t, expected, got)
 		}
 
 		// add MyBytes(~[]byte), MyString(~string) test cases to ensure no other types for switch default 

--- a/gson/gson_codec_test.go
+++ b/gson/gson_codec_test.go
@@ -160,6 +160,26 @@ func TestUnmarshalBy(t *testing.T) {
 			expected := set.New[int32](1, 2, 3)
 			assert.Nil(t, err)
 			assert.Equal(t, expected, got)
+		},
+		{
+			got, err := UnmarshalBy[*set.Set[int32]](codec, `[1,2, 3]`)
+			expected := set.New[int32](1, 2, 3)
+			assert.Nil(t, err)
+			assert.Equal(t, expected, got)
+		}
+
+		// add MyBytes(~[]byte), MyString(~string) test cases to ensure no other types for switch default 
+		{
+			got, err := UnmarshalBy[*set.Set[int32]](codec, MyBytes(`[1,2, 3]`))
+			expected := set.New[int32](1, 2, 3)
+			assert.Nil(t, err)
+			assert.Equal(t, expected, got)
+		}
+		{
+			got, err := UnmarshalBy[*set.Set[int32]](codec, MyString(`[1,2, 3]`))
+			expected := set.New[int32](1, 2, 3)
+			assert.Nil(t, err)
+			assert.Equal(t, expected, got)
 		}
 	}
 }


### PR DESCRIPTION
1. Performance improved in case of `UnmarshalBy_String` .


- standard JSON codec
```
bytedance@R4374HGKKG gson % benchstat old.txt new.txt           
goos: darwin
goarch: arm64
pkg: github.com/bytedance/gg/gson
cpu: Apple M1 Pro
                                │   old.txt   │              new.txt               │
                                │   sec/op    │   sec/op     vs base               │
UnmarshalBy_Bytes-10              446.4n ± 3%   440.2n ± 2%       ~ (p=0.123 n=10)
UnmarshalBy_String-10             464.9n ± 3%   442.1n ± 4%  -4.89% (p=0.000 n=10)
UnmarshalBy_LargeJSON_String-10   12.55µ ± 2%   12.36µ ± 3%  -1.56% (p=0.035 n=10)
UnmarshalBy_LargeJSON_Bytes-10    12.68µ ± 4%   12.36µ ± 2%  -2.54% (p=0.002 n=10)
geomean                           2.397µ        2.335µ       -2.61%
```
- sonic.ConfigFastest
```
bytedance@R4374HGKKG gson % benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/bytedance/gg/gson
cpu: Apple M1 Pro
                                │   old.txt   │              new.txt               │
                                │   sec/op    │   sec/op     vs base               │
UnmarshalBy_Bytes-10              252.3n ± 3%   247.1n ± 0%       ~ (p=0.516 n=10)
UnmarshalBy_String-10             269.5n ± 4%   251.1n ± 2%  -6.85% (p=0.000 n=10)
UnmarshalBy_LargeJSON_String-10   3.586µ ± 3%   3.337µ ± 2%  -6.94% (p=0.000 n=10)
UnmarshalBy_LargeJSON_Bytes-10    3.539µ ± 1%   3.376µ ± 3%  -4.59% (p=0.000 n=10)
geomean                           963.7n        914.3n       -5.13%

```

2. Updated docs as well.
