### PR TITLE
feat(gslice): add ToBoolMap to collect slice elements into a set (map[T]bool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ gcond.Switch[string](3).
 Processing value `T`
 
 Usage：
+
 ```go
 import (
     "github.com/bytedance/gg/gvalue"
@@ -338,7 +339,7 @@ Example5：Convert to map
 ```go
 ToMap([]int{1, 2, 3, 4, 5}, func(i int) (string, int) { return strconv.Itoa(i), i })
 // {"1":1, "2":2, "3":3, "4":4, "5":5}
-ToSet([]int{1, 2, 3, 3, 2})
+ToBoolMap([]int{1, 2, 3, 3, 2})
 // {1: true, 2: true, 3: true}
 ToMapValues([]int{1, 2, 3, 4, 5}, strconv.Itoa)
 // {"1":1, "2":2, "3":3, "4":4, "5":5}
@@ -387,6 +388,7 @@ Reverse(s4)
 Processing map `map[K]V`
 
 Usage：
+
 ```go
 import (
     "github.com/bytedance/gg/gmap"
@@ -662,7 +664,6 @@ pool.Put(a)
 
 Example3：`gsync.OnceXXX` wraps `sync.Once`
 
-
 ```go
 onceFunc := gsync.OnceFunc(func() { fmt.Println("OnceFunc") })
 onceFunc()
@@ -695,7 +696,7 @@ Implementation of tuple provides definition of generic n-ary tuples
 Usage
 
 ```go
-import (
+Timport (
     "github.com/bytedance/gg/collection/tuple"
 )
 ```

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Example5：Convert to map
 ```go
 ToMap([]int{1, 2, 3, 4, 5}, func(i int) (string, int) { return strconv.Itoa(i), i })
 // {"1":1, "2":2, "3":3, "4":4, "5":5}
+ToSet([]int{1, 2, 3, 3, 2})
+// {1: true, 2: true, 3: true}
 ToMapValues([]int{1, 2, 3, 4, 5}, strconv.Itoa)
 // {"1":1, "2":2, "3":3, "4":4, "5":5}
 GroupBy([]int{1, 2, 3, 4, 5}, func(i int) string {
@@ -596,7 +598,7 @@ import jsoniter "github.com/json-iterator/go"
 
 gson.MarshalBy(jsoniter.ConfigDefault, testcase)
 // []byte(`{"name":"test","age":10}`) nil
-gson.MarshalString(jsoniter.ConfigDefault, testcase)   
+gson.MarshalString(jsoniter.ConfigDefault, testcase)
 // {"name":"test","age":10}`, nil
 gson.UnmarshalBy[testStruct](jsoniter.ConfigDefault, `{"name":"test","age":10}`)
 // testStruct{Name: "test", Age: 10}, nil

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ Implementation of tuple provides definition of generic n-ary tuples
 Usage
 
 ```go
-Timport (
+import(
     "github.com/bytedance/gg/collection/tuple"
 )
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -338,6 +338,8 @@ gslice.Sum([]int{1, 2, 3, 4, 5})
 ```go
 ToMap([]int{1, 2, 3, 4, 5}, func(i int) (string, int) { return strconv.Itoa(i), i })
 // {"1":1, "2":2, "3":3, "4":4, "5":5}
+ToSet([]int{1, 2, 3, 3, 2})
+// {1: true, 2: true, 3: true}
 ToMapValues([]int{1, 2, 3, 4, 5}, strconv.Itoa)
 // {"1":1, "2":2, "3":3, "4":4, "5":5}
 GroupBy([]int{1, 2, 3, 4, 5}, func(i int) string {
@@ -597,7 +599,7 @@ import jsoniter "github.com/json-iterator/go"
 
 gson.MarshalBy(jsoniter.ConfigDefault, testcase)
 // []byte(`{"name":"test","age":10}`) nil
-gson.MarshalString(jsoniter.ConfigDefault, testcase)   
+gson.MarshalString(jsoniter.ConfigDefault, testcase)
 // {"name":"test","age":10}`, nil
 gson.UnmarshalBy[testStruct](jsoniter.ConfigDefault, `{"name":"test","age":10}`)
 // testStruct{Name: "test", Age: 10}, nil

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -338,7 +338,7 @@ gslice.Sum([]int{1, 2, 3, 4, 5})
 ```go
 ToMap([]int{1, 2, 3, 4, 5}, func(i int) (string, int) { return strconv.Itoa(i), i })
 // {"1":1, "2":2, "3":3, "4":4, "5":5}
-ToSet([]int{1, 2, 3, 3, 2})
+ToBoolMap([]int{1, 2, 3, 3, 2})
 // {1: true, 2: true, 3: true}
 ToMapValues([]int{1, 2, 3, 4, 5}, strconv.Itoa)
 // {"1":1, "2":2, "3":3, "4":4, "5":5}

--- a/gslice/gslice.go
+++ b/gslice/gslice.go
@@ -54,7 +54,7 @@
 //
 // Convert to Map:
 //
-//   - [ToMap], [ToMapValues]
+//   - [ToMap], [ToMapValues], [ToSet]
 //   - [GroupBy]
 //
 // Set operations:
@@ -1114,6 +1114,24 @@ func ToMap[T, V any, K comparable](s []T, f func(T) (K, V)) map[K]V {
 // 💡 AKA: Kotlin's associateBy
 func ToMapValues[T any, K comparable](s []T, f func(T) K) map[K]T {
 	return iter.ToMapValues(f, iter.StealSlice(s))
+}
+
+// ToSet collects elements of a slice into a set-like structure represented by map[T]bool.
+// Each unique element from the input slice becomes a key in the map with the value `true`.
+// Duplicate elements are automatically de-duplicated due to map key uniqueness.
+//
+// 🚀 EXAMPLE:
+//
+//	s := []int{1, 2, 2, 3}
+//	ToSet(s) ⏩ map[int]bool{1: true, 2: true, 3: true}
+//
+// 🧠 NOTE:
+//
+//	The element type T must be comparable, as required by Go map keys.
+//
+// 💡 AKA: setOf(...) in Kotlin, .toSet() in Python
+func ToSet[T comparable](s []T) map[T]bool {
+	return ToMap(s, func(t T) (T, bool) { return t, true })
 }
 
 // PtrOf returns pointers that point to equivalent elements of slice s.

--- a/gslice/gslice.go
+++ b/gslice/gslice.go
@@ -54,7 +54,7 @@
 //
 // Convert to Map:
 //
-//   - [ToMap], [ToMapValues], [ToSet]
+//   - [ToMap], [ToMapValues], [ToBoolMap]
 //   - [GroupBy]
 //
 // Set operations:
@@ -1116,21 +1116,19 @@ func ToMapValues[T any, K comparable](s []T, f func(T) K) map[K]T {
 	return iter.ToMapValues(f, iter.StealSlice(s))
 }
 
-// ToSet collects elements of a slice into a set-like structure represented by map[T]bool.
+// ToBoolMap collects elements of a slice into a set-like structure represented by map[T]bool.
 // Each unique element from the input slice becomes a key in the map with the value `true`.
 // Duplicate elements are automatically de-duplicated due to map key uniqueness.
 //
 // 🚀 EXAMPLE:
 //
 //	s := []int{1, 2, 2, 3}
-//	ToSet(s) ⏩ map[int]bool{1: true, 2: true, 3: true}
+//	ToBoolMap(s) ⏩ map[int]bool{1: true, 2: true, 3: true}
 //
-// 🧠 NOTE:
+// 💡 NOTE:
 //
 //	The element type T must be comparable, as required by Go map keys.
-//
-// 💡 AKA: setOf(...) in Kotlin, .toSet() in Python
-func ToSet[T comparable](s []T) map[T]bool {
+func ToBoolMap[T comparable](s []T) map[T]bool {
 	return ToMap(s, func(t T) (T, bool) { return t, true })
 }
 

--- a/gslice/gslice_example_test.go
+++ b/gslice/gslice_example_test.go
@@ -62,6 +62,7 @@ func Example() {
 	// Convert to Map
 	fmt.Println(gson.ToString(ToMap([]int{1, 2, 3, 4, 5}, func(i int) (string, int) { return strconv.Itoa(i), i }))) // {"1":1,"2":2,"3":3,"4":4,"5":5}
 	fmt.Println(gson.ToString(ToMapValues([]int{1, 2, 3, 4, 5}, strconv.Itoa)))                                      // {"1":1,"2":2,"3":3,"4":4,"5":5}
+	fmt.Println(gson.ToString(ToSet([]int{1, 2, 3, 3, 2})))                                                          // {1:true, 2:true, 3:true}
 	fmt.Println(gson.ToString(GroupBy([]int{1, 2, 3, 4, 5}, func(i int) string {
 		if i%2 == 0 {
 			return "even"

--- a/gslice/gslice_example_test.go
+++ b/gslice/gslice_example_test.go
@@ -62,7 +62,7 @@ func Example() {
 	// Convert to Map
 	fmt.Println(gson.ToString(ToMap([]int{1, 2, 3, 4, 5}, func(i int) (string, int) { return strconv.Itoa(i), i }))) // {"1":1,"2":2,"3":3,"4":4,"5":5}
 	fmt.Println(gson.ToString(ToMapValues([]int{1, 2, 3, 4, 5}, strconv.Itoa)))                                      // {"1":1,"2":2,"3":3,"4":4,"5":5}
-	fmt.Println(gson.ToString(ToSet([]int{1, 2, 3, 3, 2})))                                                          // {"1":true,"2":true,"3":true}
+	fmt.Println(gson.ToString(ToBoolMap([]int{1, 2, 3, 3, 2})))                                                          // {"1":true,"2":true,"3":true}
 	fmt.Println(gson.ToString(GroupBy([]int{1, 2, 3, 4, 5}, func(i int) string {
 		if i%2 == 0 {
 			return "even"

--- a/gslice/gslice_example_test.go
+++ b/gslice/gslice_example_test.go
@@ -62,7 +62,7 @@ func Example() {
 	// Convert to Map
 	fmt.Println(gson.ToString(ToMap([]int{1, 2, 3, 4, 5}, func(i int) (string, int) { return strconv.Itoa(i), i }))) // {"1":1,"2":2,"3":3,"4":4,"5":5}
 	fmt.Println(gson.ToString(ToMapValues([]int{1, 2, 3, 4, 5}, strconv.Itoa)))                                      // {"1":1,"2":2,"3":3,"4":4,"5":5}
-	fmt.Println(gson.ToString(ToSet([]int{1, 2, 3, 3, 2})))                                                          // {1:true, 2:true, 3:true}
+	fmt.Println(gson.ToString(ToSet([]int{1, 2, 3, 3, 2})))                                                          // {"1":true,"2":true,"3":true}
 	fmt.Println(gson.ToString(GroupBy([]int{1, 2, 3, 4, 5}, func(i int) string {
 		if i%2 == 0 {
 			return "even"
@@ -120,6 +120,7 @@ func Example() {
 	// 15
 	// {"1":1,"2":2,"3":3,"4":4,"5":5}
 	// {"1":1,"2":2,"3":3,"4":4,"5":5}
+	// {"1":true,"2":true,"3":true}
 	// {"even":[2,4],"odd":[1,3,5]}
 	// [1 2 3 4 5]
 	// [3]

--- a/gslice/gslice_test.go
+++ b/gslice/gslice_test.go
@@ -690,6 +690,14 @@ func TestToMap(t *testing.T) {
 		ToMap([]Foo{{1, "one"}, {2, "two"}, {3, "three"}}, mapper))
 }
 
+func TestToSet(t *testing.T) {
+	assert.Equal(t, map[int]bool{}, ToSet([]int{}))
+	assert.Equal(t, map[int]bool{1: true, 2: true, 3: true}, ToSet([]int{1, 2, 2, 3}))
+	assert.Equal(t,
+		map[string]bool{"a": true, "b": true},
+		ToSet([]string{"a", "b", "a", "a", "b"}))
+}
+
 func TestDivide(t *testing.T) {
 	{
 		s := []int{0, 1, 2, 3, 4}

--- a/gslice/gslice_test.go
+++ b/gslice/gslice_test.go
@@ -690,12 +690,12 @@ func TestToMap(t *testing.T) {
 		ToMap([]Foo{{1, "one"}, {2, "two"}, {3, "three"}}, mapper))
 }
 
-func TestToSet(t *testing.T) {
-	assert.Equal(t, map[int]bool{}, ToSet([]int{}))
-	assert.Equal(t, map[int]bool{1: true, 2: true, 3: true}, ToSet([]int{1, 2, 2, 3}))
+func TestToBoolMap(t *testing.T) {
+	assert.Equal(t, map[int]bool{}, ToBoolMap([]int{}))
+	assert.Equal(t, map[int]bool{1: true, 2: true, 3: true}, ToBoolMap([]int{1, 2, 2, 3}))
 	assert.Equal(t,
 		map[string]bool{"a": true, "b": true},
-		ToSet([]string{"a", "b", "a", "a", "b"}))
+		ToBoolMap([]string{"a", "b", "a", "a", "b"}))
 }
 
 func TestDivide(t *testing.T) {


### PR DESCRIPTION
# Add ToSet for converting slice to map[T]bool

## What

This PR adds a generic utility function ToSet, which converts a slice of comparable elements into a map[T]bool — commonly used in Go as a set.

It builds on top of ToMap but provides a more ergonomic API for a frequent use case.

## Why

In Go, it’s common to use map[T]bool as a set. While ToMap can technically be used to construct such sets:

ToMap(s, func(x T) (T, bool) { return x, true })

this approach is verbose and repetitive, especially for a pattern that’s so frequently needed in practice.

ToSet eliminates the need for writing an anonymous function every time, and makes the intent clearer at callsite.

## Motivation
- Provides a lightweight and idiomatic way to create sets in Go
- Eliminates boilerplate for common set creation patterns
- Aligns with similar patterns in other languages:
	•	toSet() in Python
	•	setOf() in Kotlin